### PR TITLE
add click handler for location

### DIFF
--- a/sdle.js
+++ b/sdle.js
@@ -41,6 +41,13 @@ function initMap() {
     infoWindow = new google.maps.InfoWindow;
     geocoder = new google.maps.Geocoder;
 
+    google.maps.event.addListener(map,'click',function(e) {
+        setMapInfo({
+            lat: e.latLng.lat(),
+            lng: e.latLng.lng()
+        });
+    });
+
     // Try HTML5 geolocation.
     if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(function(position) {


### PR DESCRIPTION
this is similar to issue #2 but instead of a drag, its just a click. Note a click is a click, clicking and holding and draging the map won't activate this, which is good. You can still move the map around but once you do a single click it will do service body lookup.